### PR TITLE
fix: 去除dist文件夹下运行时js文件对tslib的引用

### DIFF
--- a/copyShellFile.js
+++ b/copyShellFile.js
@@ -13,6 +13,14 @@ const list = [
     {
         originRelativePath: "./nsc/package.json", 
         targetRelativePath: "./dist/nsc/package.json"
+    },
+    {
+        originRelativePath: "./src/runtime-code/page-diff.js",
+        targetRelativePath: "./dist/src/runtime-code/page-diff.js"
+    },
+    {
+        originRelativePath: "./src/runtime-code/page-runtime.js",
+        targetRelativePath: "./dist/src/runtime-code/page-runtime.js"
     }
 ]
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,13 @@
     "url": "https://github.com/aa875982361/mini-wxml-render/issues"
   },
   "homepage": "https://github.com/aa875982361/mini-wxml-render#readme",
-  "devDependencies": {},
+  "devDependencies": {
+    "ts-node": "^8.10.2",
+    "tslint": "^6.1.2",
+    "tslint-eslint-rules": "^5.4.0",
+    "tslint-sonarts": "^1.9.0",
+    "typescript": "^3.9.7"
+  },
   "dependencies": {
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
@@ -38,11 +44,6 @@
     "escodegen": "^2.0.0",
     "globby": "^10.0.2",
     "himalaya": "^1.1.0",
-    "ts-node": "^8.10.2",
-    "tslib": "^2.0.0",
-    "tslint": "^6.1.2",
-    "tslint-eslint-rules": "^5.4.0",
-    "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.9.7"
+    "tslib": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-wxml-render",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "将wxml文件编译成js，并组合页面js，变成一份渲染js， 并可以通过一个承载页面渲染。",
   "main": "src/index.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "downlevelIteration": true,
     "module": "commonjs",
     "target": "es6",
-    "allowJs": true,
     "lib": [
       "es2017",
       "dom"


### PR DESCRIPTION
1. 原本使用了ts的编译，导致增加了tslib的引用